### PR TITLE
Switch Twitch API to use GraphQL calls only

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ Due to the nature of VodBot, application with Twitch and Google must be register
     "pissyellowcrocs", "percy_creates"
   ],
 
-  "twitch_client_id": "[[INSERT CLIENT ID HERE]]",
-  "twitch_client_secret": "[[INSERT CLIENT SECRET HERE]]",
-
   "stage_timezone": "US/Eastern",
   "stage_format": {
     "watch": "-- Watch live at {links}",
@@ -63,9 +60,7 @@ Due to the nature of VodBot, application with Twitch and Google must be register
 }
 ```
 
-* `twitch_channels`: names of channels on twitch to pull VODs and clips from.
-* `twitch_client_id`: ID string of client app, you must register your own with Twitch [here](https://dev.twitch.tv/console/apps).
-* `twitch_client_secret`: Secret string of client app, you must register your own with Twitch [here](https://dev.twitch.tv/console/apps).
+* `twitch_channels`: names of channels on twitch to pull VODs and clips from, specifically the names at the end of their page URLs.
 * `stage_timezone`: Timezone of the VODs/Clips, used for description formatting. Must be a useable string from the [pytz](http://pytz.sourceforge.net/) library.
 * `stage_format`: A dictionary of strings that can be formatted with special predefined strings, or other strings from the dictionary. The predefined strings are described below.
     * `date`: The date the stream started, formatted as year/month/day.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="/assets/banner.png" alt="VodBot" height="100" /> by NotQuiteApex & FTI.
+# <img src="/assets/banner.png" alt="VodBot" height="100" /> by NotQuiteApex
 A command line interface VOD and Clip manager for Twitch. Downloads VODs and Clips with appropriate metadata for any public channel, and allows for slicing and reupload to YouTube.
 
 ## Project Status

--- a/vodbot/__init__.py
+++ b/vodbot/__init__.py
@@ -1,3 +1,3 @@
 __project__ = "VodBot"
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko"

--- a/vodbot/__init__.py
+++ b/vodbot/__init__.py
@@ -1,2 +1,3 @@
 __project__ = "VodBot"
 __version__ = "1.4.1"
+TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko"

--- a/vodbot/commands/pull.py
+++ b/vodbot/commands/pull.py
@@ -18,20 +18,18 @@ def run(args):
 
 def download_twitch_video(args):
 	# Load the config and set up the access token
-	cprint("#r#dLoading config...", end=" ", flush=True)
+	cprint("#r#dLoading config...#r", end=" ", flush=True)
 	conf = util.load_conf(args.config)
 	CHANNEL_IDS = conf["twitch_channels"]
-	CLIENT_ID = conf["twitch_client_id"]
-	CLIENT_SECRET = conf["twitch_client_secret"]
 	VODS_DIR = conf["vod_dir"]
 	CLIPS_DIR = conf["clip_dir"]
 
-	cprint("Logging in to Twitch.tv...", end=" ", flush=True)
-	HEADERS = twitch.get_access_token(CLIENT_ID, CLIENT_SECRET)
-
-	# If command line has channels to watch instead, use those instead of the config ones.
-	if len(args.channels) != 0:
-		CHANNELS = args.channels
+	# If channel arguments are provided, override config
+	if args.channels:
+		CHANNEL_IDS = args.channels
+	
+	cprint("#r#dLoading channel data...#r", end=" ", flush=True)
+	channels = twitch.get_channels(CHANNEL_IDS)
 	
 	contentnoun = "video" # temp contentnoun until the rest is reworked
 	
@@ -42,10 +40,6 @@ def download_twitch_video(args):
 	util.make_dir(voddir)
 	clipdir = Path(CLIPS_DIR)
 	util.make_dir(clipdir)
-
-	# Get user channel objects from Twitch API
-	cprint("Getting User ID's...#r", flush=True)
-	channels = twitch.get_channels(CHANNEL_IDS, HEADERS)
 
 	# Get list of videos using channel object ID's from Twitch API
 	videos = []

--- a/vodbot/commands/pull.py
+++ b/vodbot/commands/pull.py
@@ -28,7 +28,7 @@ def download_twitch_video(args):
 	if args.channels:
 		CHANNEL_IDS = args.channels
 	
-	cprint("#r#dLoading channel data...#r", end=" ", flush=True)
+	cprint("#r#dLoading channel data...#r", flush=True)
 	channels = twitch.get_channels(CHANNEL_IDS)
 	
 	contentnoun = "video" # temp contentnoun until the rest is reworked
@@ -63,7 +63,7 @@ def download_twitch_video(args):
 		if args.type == "both" or args.type == "vods":
 			folder = voddir / channel.login
 			util.make_dir(folder)
-			allvods = twitch.get_channel_vods(channel, HEADERS)
+			allvods = twitch.get_channel_vods(channel)
 			vods = compare_existant_file(folder, allvods)
 			totalvods += len(vods)
 
@@ -71,7 +71,7 @@ def download_twitch_video(args):
 		if args.type == "both" or args.type == "clips":
 			folder = clipdir / channel.login
 			util.make_dir(folder)
-			allclips = twitch.get_channel_clips(channel, HEADERS)
+			allclips = twitch.get_channel_clips(channel)
 			clips = compare_existant_file(folder, allclips)
 			totalclips += len(clips)
 
@@ -95,6 +95,8 @@ def download_twitch_video(args):
 		cprint(f"Total #fMVODs#r to download: #fC#l{totalvods}#r")
 	elif args.type == "clips":
 		cprint(f"Total #fMClips#r to download: #fC#l{totalclips}#r")
+
+	return
 
 	# Download all the videos we need.
 	previouschannel = None

--- a/vodbot/commands/pull.py
+++ b/vodbot/commands/pull.py
@@ -96,8 +96,6 @@ def download_twitch_video(args):
 	elif args.type == "clips":
 		cprint(f"Total #fMClips#r to download: #fC#l{totalclips}#r")
 
-	return
-
 	# Download all the videos we need.
 	previouschannel = None
 	for vod in videos:

--- a/vodbot/itd/download.py
+++ b/vodbot/itd/download.py
@@ -93,10 +93,10 @@ def dl_video(video: Vod, path: str, metapath: str, max_workers: int):
 
 
 def dl_clip(clip: Clip, path: str, metapath: str):
-	clip_id = clip.id
+	clip_slug = clip.slug
 
 	# Get proper clip file URL
-	source_url = gql.get_clip_source(clip_id)
+	source_url = gql.get_clip_source(clip_slug)
 
 	# Download file to path
 	size = worker.download_file(source_url, path)
@@ -105,4 +105,4 @@ def dl_clip(clip: Clip, path: str, metapath: str):
 	clip.write_meta(metapath)
 
 	# Print progress
-	cprint(f"#fM#lClip#r `#fM{clip_id}#r` #fB#l~{worker.format_size(size)}#r")
+	cprint(f"#fM#lClip#r `#fM{clip_slug}#r` #fB#l~{worker.format_size(size)}#r")

--- a/vodbot/itd/gql.py
+++ b/vodbot/itd/gql.py
@@ -44,36 +44,17 @@ GET_CHANNEL_VIDEOS_QUERY = """
 {{
 	user(login: "{channel_id}") {{
 		videos(
-			first: {first},
-			type: {type},
-			sort: {sort},
-			after: "{after}",
-			options: {{
-				gameIDs: []
-			}}
+			first: {first}, type: {type},
+			sort: {sort}, after: "{after}"
 		) {{
 			totalCount
-			pageInfo {{
-				hasNextPage
-				hasPreviousPage
-			}}
-			edges {{
-				cursor
-				node {{
-					id
-					title
-					publishedAt
-					broadcastType
-					lengthSeconds
-					thumbnailURLs
-					game {{
-						name
-					}}
-					creator {{
-						id
-						login
-						displayName
-					}}
+			pageInfo {{ hasNextPage hasPreviousPage }}
+			edges {{ cursor
+				node {{ id title
+					publishedAt broadcastType
+					lengthSeconds thumbnailURLs
+					game {{ id name }}
+					creator {{ id login displayName }}
 				}}
 			}}
 		}}
@@ -86,42 +67,18 @@ GET_CHANNEL_CLIPS_QUERY = """
 {{
 	user(login: "{channel_id}") {{
 		clips(
-			first: {first},
-			after: "{after}",
+			first: {first}, after: "{after}",
 			criteria: {{ period: ALL_TIME, sort: VIEWS_DESC }}
-			) {{
-			pageInfo {{
-				hasNextPage
-			}}
-			edges {{
-				cursor
-				node {{
-					id
-					slug
-					title
-					createdAt
-					viewCount
-					durationSeconds
-					url
-					videoQualities {{
-						frameRate
-						quality
-						sourceURL
-					}}
-					game {{
-						id
-						name
-					}}
-					broadcaster {{
-						id
-						displayName
-						login
-					}}
-					curator {{
-						id
-						displayName
-						login
-					}}
+		) {{
+			pageInfo {{ hasNextPage }}
+			edges {{ cursor
+				node {{ id slug title
+					createdAt viewCount
+					durationSeconds url
+					videoQualities {{ frameRate quality sourceURL }}
+					game {{ id name }}
+					broadcaster {{ id displayName login }}
+					curator {{ id displayName login }}
 				}}
 			}}
 		}}
@@ -132,18 +89,10 @@ GET_CHANNEL_CLIPS_QUERY = """
 GET_VIDEO_QUERY = """
 {{
 	video(id: "{video_id}") {{
-		id
-		title
-		publishedAt
-		broadcastType
-		lengthSeconds
-		game {{
-			name
-		}}
-		creator {{
-			login
-			displayName
-		}}
+		id title publishedAt
+		broadcastType lengthSeconds
+		game {{ id name }}
+		creator {{ id login displayName }}
 	}}
 }}
 """
@@ -151,26 +100,11 @@ GET_VIDEO_QUERY = """
 GET_CLIP_QUERY = """
 {{
 	clip(slug: "{clip_slug}") {{
-		id
-		slug
-		title
-		createdAt
-		viewCount
-		durationSeconds
-		url
-		videoQualities {{
-			frameRate
-			quality
-			sourceURL
-		}}
-		game {{
-			id
-			name
-		}}
-		broadcaster {{
-			displayName
-			login
-		}}
+		id slug title createdAt
+		viewCount durationSeconds url
+		videoQualities {{ frameRate quality sourceURL }}
+		game {{ id name }}
+		broadcaster {{ id displayName login }}
 	}}
 }}
 """
@@ -178,23 +112,13 @@ GET_CLIP_QUERY = """
 GET_CHANNEL_QUERY = """
 {{
 	user(login: "{channel_id}") {{
-		id
-		login
-		displayName
-		description
-		createdAt
-		roles {{
-			isPartner
-		}}
+		id login displayName
+		description createdAt
+		roles {{ isPartner }}
 		stream {{
-			id
-			title
-			type
-			viewersCount
-			createdAt
-			game {{
-				name
-			}}
+			id title type
+			viewersCount createdAt
+			game {{ id name }}
 		}}
 	}}
 }}
@@ -210,10 +134,7 @@ VIDEO_ACCESS_QUERY = """
 			playerBackend: "mediaplayer",
 			playerType: "site"
 		}}
-	) {{
-		signature
-		value
-	}}
+	) {{ signature value }}
 }}
 """
 

--- a/vodbot/itd/gql.py
+++ b/vodbot/itd/gql.py
@@ -48,13 +48,11 @@ GET_CHANNEL_VIDEOS_QUERY = """
 			type: {type},
 			sort: {sort},
 			after: "{after}",
-			options: {{
-				gameIDs: {game_ids}
-			}}
 		) {{
 			totalCount
 			pageInfo {{
 				hasNextPage
+				hasPreviousPage
 			}}
 			edges {{
 				cursor
@@ -64,6 +62,7 @@ GET_CHANNEL_VIDEOS_QUERY = """
 					publishedAt
 					broadcastType
 					lengthSeconds
+					thumbnailUrl
 					game {{
 						name
 					}}
@@ -78,6 +77,7 @@ GET_CHANNEL_VIDEOS_QUERY = """
 }}
 """
 # Channel Clips query
+# period can be LAST_DAY, LAST_WEEK, LAST_MONTH, or ALL_TIME
 GET_CHANNEL_CLIPS_QUERY = """
 {{
 	user(login: "{channel_id}") {{
@@ -110,6 +110,10 @@ GET_CHANNEL_CLIPS_QUERY = """
 						name
 					}}
 					broadcaster {{
+						displayName
+						login
+					}}
+					creator {{
 						displayName
 						login
 					}}

--- a/vodbot/itd/gql.py
+++ b/vodbot/itd/gql.py
@@ -150,7 +150,7 @@ GET_VIDEO_QUERY = """
 # Single Clip query
 GET_CLIP_QUERY = """
 {{
-	clip(slug: "{clip_id}") {{
+	clip(slug: "{clip_slug}") {{
 		id
 		slug
 		title
@@ -228,10 +228,8 @@ def get_access_token(video_id):
 	return resp["data"]["videoPlaybackAccessToken"]
 
 
-CLIP_SOURCE_QUERY = GET_CLIP_QUERY
-
-def get_clip_source(clip_id):
-	query = CLIP_SOURCE_QUERY.format(clip_id)
+def get_clip_source(clip_slug):
+	query = GET_CLIP_QUERY.format(clip_slug=clip_slug)
 
 	resp = gql_query(query=query).json()
 
@@ -240,7 +238,7 @@ def get_clip_source(clip_id):
 	query = {
 		"operationName": "VideoAccessToken_Clip",
 		"variables": {
-			"slug": clip_id
+			"slug": clip_slug
 		},
 		"extensions": {
 			"persistedQuery": {

--- a/vodbot/itd/gql.py
+++ b/vodbot/itd/gql.py
@@ -44,10 +44,13 @@ GET_CHANNEL_VIDEOS_QUERY = """
 {{
 	user(login: "{channel_id}") {{
 		videos(
-			first: {limit},
+			first: {first},
 			type: {type},
 			sort: {sort},
 			after: "{after}",
+			options: {{
+				gameIDs: []
+			}}
 		) {{
 			totalCount
 			pageInfo {{
@@ -62,11 +65,12 @@ GET_CHANNEL_VIDEOS_QUERY = """
 					publishedAt
 					broadcastType
 					lengthSeconds
-					thumbnailUrl
+					thumbnailURLs
 					game {{
 						name
 					}}
 					creator {{
+						id
 						login
 						displayName
 					}}
@@ -82,13 +86,12 @@ GET_CHANNEL_CLIPS_QUERY = """
 {{
 	user(login: "{channel_id}") {{
 		clips(
-			first: {limit},
+			first: {first},
 			after: "{after}",
-			criteria: {{ period: {period}, sort: VIEWS_DESC }}
+			criteria: {{ period: ALL_TIME, sort: VIEWS_DESC }}
 			) {{
 			pageInfo {{
 				hasNextPage
-				hasPreviousPage
 			}}
 			edges {{
 				cursor
@@ -110,10 +113,12 @@ GET_CHANNEL_CLIPS_QUERY = """
 						name
 					}}
 					broadcaster {{
+						id
 						displayName
 						login
 					}}
-					creator {{
+					curator {{
+						id
 						displayName
 						login
 					}}

--- a/vodbot/itd/gql.py
+++ b/vodbot/itd/gql.py
@@ -38,15 +38,12 @@ def gql_query(query=None, data=None):
 	_process_query_errors(resp)
 	return resp
 
+
 # GQL Query forms
 # Channel VODs query
 GET_CHANNEL_VIDEOS_QUERY = """
-{{
-	user(login: "{channel_id}") {{
-		videos(
-			first: {first}, type: {type},
-			sort: {sort}, after: "{after}"
-		) {{
+{{  user(login: "{channel_id}") {{
+		videos( first: {first}, type: {type}, sort: {sort}, after: "{after}" ) {{
 			totalCount
 			pageInfo {{ hasNextPage hasPreviousPage }}
 			edges {{ cursor
@@ -55,17 +52,12 @@ GET_CHANNEL_VIDEOS_QUERY = """
 					lengthSeconds thumbnailURLs
 					game {{ id name }}
 					creator {{ id login displayName }}
-				}}
-			}}
-		}}
-	}}
-}}
+}}  }}  }}  }}  }}
 """
 # Channel Clips query
 # period can be LAST_DAY, LAST_WEEK, LAST_MONTH, or ALL_TIME
 GET_CHANNEL_CLIPS_QUERY = """
-{{
-	user(login: "{channel_id}") {{
+{{  user(login: "{channel_id}") {{
 		clips(
 			first: {first}, after: "{after}",
 			criteria: {{ period: ALL_TIME, sort: VIEWS_DESC }}
@@ -79,39 +71,30 @@ GET_CHANNEL_CLIPS_QUERY = """
 					game {{ id name }}
 					broadcaster {{ id displayName login }}
 					curator {{ id displayName login }}
-				}}
-			}}
-		}}
-	}}
-}}
+}}  }}  }}  }}  }}
 """
 # Single VOD query
 GET_VIDEO_QUERY = """
-{{
-	video(id: "{video_id}") {{
+{{ video(id: "{video_id}") {{
 		id title publishedAt
 		broadcastType lengthSeconds
 		game {{ id name }}
 		creator {{ id login displayName }}
-	}}
-}}
+}}  }}
 """
 # Single Clip query
 GET_CLIP_QUERY = """
-{{
-	clip(slug: "{clip_slug}") {{
+{{  clip(slug: "{clip_slug}") {{
 		id slug title createdAt
 		viewCount durationSeconds url
 		videoQualities {{ frameRate quality sourceURL }}
 		game {{ id name }}
 		broadcaster {{ id displayName login }}
-	}}
-}}
+}}  }}
 """
 # Channel info query
 GET_CHANNEL_QUERY = """
-{{
-	user(login: "{channel_id}") {{
+{{  user(login: "{channel_id}") {{
 		id login displayName
 		description createdAt
 		roles {{ isPartner }}
@@ -119,15 +102,12 @@ GET_CHANNEL_QUERY = """
 			id title type
 			viewersCount createdAt
 			game {{ id name }}
-		}}
-	}}
-}}
+}}  }}  }}
 """
 
 
 VIDEO_ACCESS_QUERY = """
-{{
-	videoPlaybackAccessToken(
+{{  videoPlaybackAccessToken(
 		id: {video_id},
 		params: {{
 			platform: "web",

--- a/vodbot/itd/gql.py
+++ b/vodbot/itd/gql.py
@@ -38,6 +38,159 @@ def gql_query(query=None, data=None):
 	_process_query_errors(resp)
 	return resp
 
+# GQL Query forms
+# Channel VODs query
+GET_CHANNEL_VIDEOS_QUERY = """
+{{
+	user(login: "{channel_id}") {{
+		videos(
+			first: {limit},
+			type: {type},
+			sort: {sort},
+			after: "{after}",
+			options: {{
+				gameIDs: {game_ids}
+			}}
+		) {{
+			totalCount
+			pageInfo {{
+				hasNextPage
+			}}
+			edges {{
+				cursor
+				node {{
+					id
+					title
+					publishedAt
+					broadcastType
+					lengthSeconds
+					game {{
+						name
+					}}
+					creator {{
+						login
+						displayName
+					}}
+				}}
+			}}
+		}}
+	}}
+}}
+"""
+# Channel Clips query
+GET_CHANNEL_CLIPS_QUERY = """
+{{
+	user(login: "{channel_id}") {{
+		clips(
+			first: {limit},
+			after: "{after}",
+			criteria: {{ period: {period}, sort: VIEWS_DESC }}
+			) {{
+			pageInfo {{
+				hasNextPage
+				hasPreviousPage
+			}}
+			edges {{
+				cursor
+				node {{
+					id
+					slug
+					title
+					createdAt
+					viewCount
+					durationSeconds
+					url
+					videoQualities {{
+						frameRate
+						quality
+						sourceURL
+					}}
+					game {{
+						id
+						name
+					}}
+					broadcaster {{
+						displayName
+						login
+					}}
+				}}
+			}}
+		}}
+	}}
+}}
+"""
+# Single VOD query
+GET_VIDEO_QUERY = """
+{{
+	video(id: "{video_id}") {{
+		id
+		title
+		publishedAt
+		broadcastType
+		lengthSeconds
+		game {{
+			name
+		}}
+		creator {{
+			login
+			displayName
+		}}
+	}}
+}}
+"""
+# Single Clip query
+GET_CLIP_QUERY = """
+{{
+	clip(slug: "{clip_id}") {{
+		id
+		slug
+		title
+		createdAt
+		viewCount
+		durationSeconds
+		url
+		videoQualities {{
+			frameRate
+			quality
+			sourceURL
+		}}
+		game {{
+			id
+			name
+		}}
+		broadcaster {{
+			displayName
+			login
+		}}
+	}}
+}}
+"""
+# Channel info query
+GET_CHANNEL_QUERY = """
+{{
+	user(login: "{channel_id}") {{
+		id
+		login
+		displayName
+		description
+		createdAt
+		roles {{
+			isPartner
+		}}
+		stream {{
+			id
+			title
+			type
+			viewersCount
+			createdAt
+			game {{
+				name
+			}}
+		}}
+	}}
+}}
+"""
+
 
 VIDEO_ACCESS_QUERY = """
 {{
@@ -66,32 +219,7 @@ def get_access_token(video_id):
 	return resp["data"]["videoPlaybackAccessToken"]
 
 
-CLIP_SOURCE_QUERY = """
-{{
-	clip(slug: "{}") {{
-		id
-		slug
-		title
-		createdAt
-		viewCount
-		durationSeconds
-		url
-		videoQualities {{
-			frameRate
-			quality
-			sourceURL
-		}}
-		game {{
-			id
-			name
-		}}
-		broadcaster {{
-			displayName
-			login
-		}}
-	}}
-}}
-"""
+CLIP_SOURCE_QUERY = GET_CLIP_QUERY
 
 def get_clip_source(clip_id):
 	query = CLIP_SOURCE_QUERY.format(clip_id)

--- a/vodbot/itd/gql.py
+++ b/vodbot/itd/gql.py
@@ -100,22 +100,20 @@ def get_clip_source(clip_id):
 
 	url = resp["data"]["clip"]["videoQualities"][0]["sourceURL"]
 
-	query = """
-	{{
+	query = {
 		"operationName": "VideoAccessToken_Clip",
-		"variables": {{
-			"slug": "{slug}"
-		}},
-		"extensions": {{
-			"persistedQuery": {{
+		"variables": {
+			"slug": clip_id
+		},
+		"extensions": {
+			"persistedQuery": {
 				"version": 1,
 				"sha256Hash": "36b89d2507fce29e5ca551df756d27c1cfe079e2609642b4390aa4c35796eb11"
-			}}
-		}}
-	}}
-    """
+			}
+		}
+	}
 
-	resp = gql_query(data=query.format(slug=clip_id).strip()).json()
+	resp = gql_post(json=query).json()
 	token = resp["data"]["clip"]["playbackAccessToken"]
 	token = urlencode({
 		"sig": token["signature"],

--- a/vodbot/itd/worker.py
+++ b/vodbot/itd/worker.py
@@ -1,5 +1,7 @@
 # Based on https://github.com/ihabunek/twitch-dl/blob/master/twitchdl/download.py
-# Modified to fit the project a bit better, licensed under GPLv3.
+# Modified to fit the project a bit better, originally licensed under GPLv3.
+# Modifications include shortening some functions, removing redundant bits,
+# and changing certain printouts to be more colorful.
 
 from vodbot.printer import cprint
 

--- a/vodbot/twitch.py
+++ b/vodbot/twitch.py
@@ -12,9 +12,15 @@ class Vod:
 		self.user_id = json["creator"]["id"]
 		self.user_login = json["creator"]["login"]
 		self.user_name = json["creator"]["displayName"]
+		if json["game"]:
+			self.game_id = json["game"]["id"]
+			self.game_name = json["game"]["name"]
+		else:
+			self.game_id = ""
+			self.game_name = ""
 		self.title = json["title"]
 		self.created_at = json["publishedAt"]
-		self.duration = json["lengthSeconds"]
+		self.length = json["lengthSeconds"]
 		
 		self.url = f"twitch.tv/videos/{self.id}"
 	
@@ -27,9 +33,11 @@ class Vod:
 			"user_id": self.user_id,
 			"user_login": self.user_login,
 			"user_name": self.user_name,
+			"game_id": self.game_id,
+			"game_name": self.game_name,
 			"title": self.title,
 			"created_at": self.created_at,
-			"duration": self.duration
+			"length": self.length
 		}
 		
 		with open(filename, "w") as f:
@@ -51,9 +59,16 @@ class Clip:
 			self.clipper_id = json["curator"]["id"]
 			self.clipper_login = json["curator"]["login"]
 			self.clipper_name = json["curator"]["displayName"]
+		if json["game"]:
+			self.game_id = json["game"]["id"]
+			self.game_name = json["game"]["name"]
+		else:
+			self.game_id = ""
+			self.game_name = ""
 		self.title = json["title"]
 		self.created_at = json["createdAt"]
 		self.view_count = json["viewCount"]
+		self.length = json["durationSeconds"]
 		
 		self.url = f"twitch.tv/{self.user_name}/clip/{self.id}"
 	
@@ -70,9 +85,12 @@ class Clip:
 			"clipper_id": self.clipper_id,
 			"clipper_login": self.clipper_login,
 			"clipper_name": self.clipper_name,
+			"game_id": self.game_id,
+			"game_name": self.game_name,
 			"title": self.title,
 			"created_at": self.created_at,
-			"view_count": self.view_count
+			"view_count": self.view_count,
+			"length": self.length
 		}
 		
 		with open(filename, "w") as f:

--- a/vodbot/twitch.py
+++ b/vodbot/twitch.py
@@ -1,5 +1,7 @@
 # Module to make API calls to Twitch.tv
 
+from . import TWITCH_CLIENT_ID
+
 import requests
 import json
 

--- a/vodbot/twitch.py
+++ b/vodbot/twitch.py
@@ -111,25 +111,15 @@ def get_access_token(CLIENT_ID, CLIENT_SECRET):
 	return headers
 
 
-def get_channels(channel_ids, headers):
+def get_channels(channel_ids):
 	"""
 	Uses a (blocking) HTTP request to retrieve channel information from Twitch's API.
 
 	:param channel_ids: A list of channel login name strings.
-	:param headers: The headers returned from get_access_token.
 	:returns: A list of Channel objects.
 	"""
 
-	url = "https://api.twitch.tv/helix/users?" + "&".join(f"login={i}" for i in channel_ids)
-	resp = requests.get(url, headers=headers)
-
-	# Some basic checks
-	if resp.status_code != 200:
-		util.exit_prog(5, f"Failed to get user ID's from Twitch. Status: {resp.status_code}")
-	try:
-		resp = resp.json()
-	except ValueError:
-		util.exit_prog(12, f"Could not parse response json for user ID's.")
+	
 	
 	# Make channel objects and store them in a list
 	channels = []

--- a/vodbot/twitch.py
+++ b/vodbot/twitch.py
@@ -52,9 +52,14 @@ class Clip:
 			self.user_id = json["broadcaster"]["id"]
 			self.user_login = json["broadcaster"]["login"]
 			self.user_name = json["broadcaster"]["displayName"]
-			self.clipper_id = json["curator"]["id"]
-			self.clipper_login = json["curator"]["login"]
-			self.clipper_name = json["curator"]["displayName"]
+			if not json["curator"]:
+				self.clipper_id = self.user_id
+				self.clipper_login = self.user_login
+				self.clipper_name = self.user_name
+			else:
+				self.clipper_id = json["curator"]["id"]
+				self.clipper_login = json["curator"]["login"]
+				self.clipper_name = json["curator"]["displayName"]
 			self.title = json["title"]
 			self.created_at = json["createdAt"]
 			self.view_count = json["viewCount"]

--- a/vodbot/util.py
+++ b/vodbot/util.py
@@ -16,9 +16,6 @@ DEFAULT_CONF = OrderedDict([
 		"juicibit", "michiri9", "notquiteapex",
 		"pissyellowcrocs", "percy_creates", "voobo",
 	]),
-	
-	("twitch_client_id", "[[INSERT TWITCH CLIENT ID HERE]]"),
-	("twitch_client_secret", "[[INSERT TWITCH CLIENT SECRET HERE]]"),
 
 	("stage_timezone", "US/Eastern"),
 
@@ -85,9 +82,6 @@ def load_conf(filename):
 	for key in DEFAULT_CONF:
 		if key not in conf:
 			exit_prog(79, f"Missing key \"{key}\" in config, please edit your config to continue.")
-	
-	if conf["twitch_client_id"] == "" or conf["twitch_client_secret"] == "":
-		exit_prog(3, "Please edit your config with your Client ID and Secret.")
 	
 	if conf["youtube_client_path"] == "":
 		cprint("Please edit your config with your Youtube Client ID and Secret to use the upload command.")


### PR DESCRIPTION
Removes the necessity of having a registered Twitch App, which is mostly out of scope of this project, and uses all public, although undocumented, API calls from Twitch's website.

Closes #17 