### PR TITLE
Stream chapters

### DIFF
--- a/vodbot/commands/pull.py
+++ b/vodbot/commands/pull.py
@@ -130,12 +130,12 @@ def download_twitch_video(args):
 					itd_dl.dl_video_chat(vod, chatname)
 					vod.has_chat = True
 				# download video
-				itd_dl.dl_video(vod, Path(TEMP_DIR), filename, 20, LOG_LEVEL)
+				#itd_dl.dl_video(vod, Path(TEMP_DIR), filename, 20, LOG_LEVEL)
 				# write meta file
 				vod.write_meta(metaname)
 			elif isinstance(vod, Clip):
 				# download clip
-				itd_dl.dl_clip(vod, filename)
+				#itd_dl.dl_clip(vod, filename)
 				# write meta file
 				vod.write_meta(metaname)
 		except itd_dl.JoiningFailed:

--- a/vodbot/commands/stage.py
+++ b/vodbot/commands/stage.py
@@ -394,11 +394,10 @@ def _new(args, conf, stagedir):
 			for c in vid["chapters"]:
 				(pos, end) = posdur_to_timestamp(c['pos'], c['dur'])
 				ch.append(f"`{c['desc']}` ({pos}-{end})")
-			cprint(" | ".join(ch) + "#r")
+			cprint(" | ".join(ch) + " | EOF#r")
 		else:
-			chap = vid["chapters"][0]
-			(pos, end) = posdur_to_timestamp(chap['pos'], chap['dur'])
-			cprint(f"#dChapter: `{chap['desc']}` ({pos}-{end})#r")
+			(pos, end) = posdur_to_timestamp(0, vid['length'])
+			cprint(f"#dChapter: `{vid['game_name']}` ({pos}-{end}) | EOF#r")
 		args.ss += [check_time("Start", args.ss[x] if x < len(args.ss) else None)]
 		args.to += [check_time("End", args.to[x] if x < len(args.to) else None)]
 

--- a/vodbot/itd/gql.py
+++ b/vodbot/itd/gql.py
@@ -108,6 +108,15 @@ GET_VIDEO_COMMENTS_QUERY = """
 				fragments {{ mention {{ displayName }} text }}
 }}  }}  }}  }}  }} }}
 """
+# VOD chapters query
+GET_VIDEO_CHAPTERS = """{{
+video(id: {id}) {{
+    moments(first=100, momentRequestType: VIDEO_CHAPTER_MARKERS, after: "{after}") {{
+        edges {{ cursor node {{
+            createdAt description
+            positionMilliseconds durationMilliseconds
+}}  }}  }}  }}  }}
+"""
 
 
 VIDEO_ACCESS_QUERY = """

--- a/vodbot/itd/gql.py
+++ b/vodbot/itd/gql.py
@@ -111,10 +111,11 @@ GET_VIDEO_COMMENTS_QUERY = """
 # VOD chapters query
 GET_VIDEO_CHAPTERS = """{{
 video(id: {id}) {{
-    moments(first=100, momentRequestType: VIDEO_CHAPTER_MARKERS, after: "{after}") {{
+    moments(first:100, momentRequestType: VIDEO_CHAPTER_MARKERS, after: "{after}") {{
         edges {{ cursor node {{
-            createdAt description
-            positionMilliseconds durationMilliseconds
+            description type
+            positionMilliseconds
+			durationMilliseconds
 }}  }}  }}  }}  }}
 """
 

--- a/vodbot/twitch.py
+++ b/vodbot/twitch.py
@@ -300,8 +300,8 @@ def get_channel_vods(channel: Channel) -> List[Vod]:
 					chapters.append(
 						VodChapter(
 							type=n["type"], description=n["description"],
-							position=n["positionMilliseconds"],
-							duration=n["durationMilliseconds"]
+							position=int(n["positionMilliseconds"]/1000),
+							duration=int(n["durationMilliseconds"]/1000)
 						)
 					)
 				


### PR DESCRIPTION
Stores info on stream chapters, which are only populated if more than 1 chapter exists for a stream. The intent is to help guide the user staging data on when/where to slice certain sections of a stream, while also archiving said info with the stream metadata.

Closes #34.